### PR TITLE
Update website.pp

### DIFF
--- a/manifests/website.pp
+++ b/manifests/website.pp
@@ -15,7 +15,6 @@
 # @example
 #   include teched_hello_world::website
 class teched_hello_world::website {
-
   file { '/var/www/':
     ensure => directory,
     before => [File['index.html'], File['css-directory'], File['img-directory'], File['js-directory']],


### PR DESCRIPTION
Removed empty line which is now considered a linting error.

```
pdk (ERROR): puppet-lint: there should be a single space or single newline after an opening brace (manifests/website.pp:18:1)
```

The error message itself is misleading as what it's really complaining about is the blank line between the class declaration and the first resource. I think it makes the code look ugly/inconsistent and have already raised a ticket 
https://perforce.atlassian.net/browse/CAT-1818 but this now the prefered standard. 